### PR TITLE
Correct outdated docs for post-installation validation

### DIFF
--- a/installing-tas-for-kubernetes.html.md.erb
+++ b/installing-tas-for-kubernetes.html.md.erb
@@ -133,8 +133,5 @@ To enable buildpack-based apps to run on Tanzu Application Service for Kubernete
 1. Push the test app to the installation:
   <pre><code>$ cf push test-app --hostname test-app</code></pre>
 
-1. While the `cf push` command is running, open another terminal pane and monitor the build logs:
-  <pre><code>$ cf logs test-app</code></pre>
-
 1. After the `cf push` command succeeds, make a request to the app:
-  <pre><code>$ curl test-app.PLACEHOLDER-SYSTEM-DOMAIN</code></pre>
+  <pre><code>$ curl test-app.apps.PLACEHOLDER-SYSTEM-DOMAIN</code></pre>


### PR DESCRIPTION
- `cf push` now streams the staging logs, so it's not necessary to run
  `cf logs` in the background

- There is now a separate apps domain, so the curl command required an
  update

Co-authored-by: Mark Stokan <mstokan@pivotal.io>
Co-authored-by: Matt Royal <mroyal@pivotal.io>

[#173048225](https://www.pivotaltracker.com/story/show/173048225)