### PR TITLE
v0.2: fix cf-for-k8s version in component list

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -17,7 +17,7 @@ both the system components and the application instances as Kubernetes workloads
 
 Tanzu Application Service for Kubernetes includes the following components:
 
-* [cf-for-k8s @ 8946c14](https://github.com/cloudfoundry/cf-for-k8s/commit/8946c1488920e59759cddd60eb8e53d1b7be224b)
+* [cf-for-k8s @ 5d8a7e1](https://github.com/cloudfoundry/cf-for-k8s/commit/5d8a7e16ca84b30c979666ff4562d0d5fc31726b)
 * [kpack v0.0.8](https://github.com/pivotal/kpack/releases/tag/v0.0.8)
 * [Cloud-Native Buildpacks for Ubuntu Bionic v0.0.55](https://hub.docker.com/layers/cloudfoundry/cnb/0.0.55-bionic/images/sha256-0a718640a4bde8ff65eb00e891ff7f4f23ffd9a0af44d43f6033cc5809768945)
 


### PR DESCRIPTION
This version reference is based on the cf-for-k8s commit SHA in v0.2.0
of the TAS for K8s source repository, at
https://github.com/pivotal/tanzu-application-service/blob/v0.2.0/vendir.lock.yml#L6.