### PR TITLE
Add library/ref to the top of load-balancer-values.yml

### DIFF
--- a/configuring-installation-values.html.md.erb
+++ b/configuring-installation-values.html.md.erb
@@ -89,6 +89,7 @@ To enable using a LoadBalancer service for the Istio ingress gateway:
 1. Populate the `load-balancer-values.yml` file with the following content:
 
     ```yaml
+    #@library/ref "@github.com/cloudfoundry/cf-for-k8s"
     #@data/values
     ---
     enable_load_balancer: True


### PR DESCRIPTION
This is necessary for recent versions of CF-for-k8s,
which have introduced their own version of this configuration
data value.

Related: https://www.pivotaltracker.com/story/show/174263650

Co-authored-by: Evan Farrar <efarrar@pivotal.io>
Co-authored-by: Angela Chin <achin@pivotal.io>