### PR TITLE
Clarify how directories relate to each other

### DIFF
--- a/configuring-installation-values.html.md.erb
+++ b/configuring-installation-values.html.md.erb
@@ -42,8 +42,7 @@ TAS for Kubernetes installation script.
 To generate the internal values, credentials and certificates needed during TAS for Kubernetes installation, 
 use a helper script in the installation resources:
 
-1. Create a directory named `configuration-values` in the same directory as the 
-`tanzu-application-service` directory. 
+1. In the same directory that contains `tanzu-application-service`, create a new directory named `configuration-values`.
 You will use this directory to store configuration values for this installation.
 
 1. Change directory to the new `tanzu-application-service` directory.


### PR DESCRIPTION
Clarify how to configuration-values and tanzu-application-service directory relate to each other

* Received feedback that the previous wording was confusing and could be
easily read as `configuration-values` being nested inside
`tanzu-application-service`.

Co-authored-by: Angela Chin <achin@pivotal.io>
Co-authored-by: Nancy Hsieh <nhsieh@pivotal.io>