### PR TITLE
Apps Manager: Remove invitation service configuration

### DIFF
--- a/configuring-apps-manager.html.md.erb
+++ b/configuring-apps-manager.html.md.erb
@@ -29,6 +29,10 @@ To customize Apps Manager:
 For more information about Apps Manager, see 
 [Getting Started with Apps Manager](https://docs.run.pivotal.io/console/dev-console.html).
 
+<p class="note"><strong>Note:</strong> Users are currently unable to invite members to orgs and spaces through Apps Manager.
+  This feature depends on the Notifications Service, which is not yet available on TAS for Kubernetes.
+</p>
+
 
 ## <a id='prerequisites'></a> Prerequisites
 
@@ -82,7 +86,7 @@ apps_manager:
   poll_interval: 30
 
   resources:
-    memory: 128
+    instances: 1
 
   whitelabeling:
     accent_color: "#00A79D"
@@ -90,11 +94,6 @@ apps_manager:
 search_server:
   resources:
     instances: 2
-
-invitations:
-  resources:
-    instances: 2
-    memory: 256
 ```
 
 To customize Apps Manager:
@@ -108,14 +107,8 @@ To customize Apps Manager:
     * [Configure Apps Manager Resources](#customize-apps-manager-resources)  
     * [Configure Apps Manager White-Labeling](#customize-apps-manager-white-label) 
     * [Configure the Apps Manager Search Server](#customize-apps-manager-searchserver)
-    * [Configure Apps Manager Invitations](#customize-apps-manager-invitations)
 
 ### <a id='customize-apps-manager-configuration'></a> Configure Apps Manager Base Settings
-
-<p class="note"><strong>Note:</strong> The <code>enable_invitations</code> configuration defaults to false.
-  The invitations service depends on the notification service, which is currently unavailable.
-  If <code>enable_invitations</code> is set to true, users do not receive email notifications to continue creating their account.
-</p>
 
 To configure Apps Manager base settings:
 
@@ -134,7 +127,6 @@ should be a well formatted YAML file.
     apps_manager:
       currency_lookup: {"usd":"$","eur":"€"}
       display_plan_prices: "false"
-      enable_invitations: "false"
       poll_interval: 30
       app_details_poll_interval: 10
     ```
@@ -149,7 +141,6 @@ The following are all of the configurable Apps Manager base settings:
   </tr>
 <tr><td>currency\_lookup</td><td>{"usd":"$","eur":"€"}</td><td>Supported currency symbols</td></tr>
 <tr><td>display\_plan\_prices</td><td>false</td><td>Display Marketplace Service Plan Prices</td></tr>
-<tr><td>enable\_invitations</td><td>false</td><td>Enable inviting users through the invitation service</td></tr>
 <tr><td>poll\_interval</td><td>30</td><td>The Apps Manager poll interval. Enter value in seconds.</td></tr>
 <tr><td>app\_details\_poll\_interval</td><td>10</td><td>The app details polling interval. Enter value in seconds.</td></tr>
 </table>
@@ -176,8 +167,6 @@ should be a well formatted YAML file.
 
       resources:
         instances: 1
-        memory: 128
-
     ```
 1. Save the configuration file.
 
@@ -190,7 +179,6 @@ The following are all of the configurable Apps Manager resource usage settings:
     <th width="40%">Description</th>
   </tr>
 <tr><td>instances</td><td>1</td><td>Deployed instances of Apps Manager.</td></tr>
-<tr><td>memory</td><td>128</td><td>Memory usage of Apps Manager in MB. Supports units, for example, `1GB`, `512MB`.</td></tr>
 </table>
 
 
@@ -214,7 +202,6 @@ should be a well formatted YAML file.
     search_server:
       resources:
         instances: 2
-        memory: 256
     ```
 1. Save the configuration file.
 
@@ -227,45 +214,8 @@ The following are all of the configurable Apps Manager Search Server settings:
     <th width="40%">Description</th>
   </tr>
 <tr><td>instances</td><td>2</td><td>Deployed instances of Apps Manager Search Server.</td></tr>
-<tr><td>memory</td><td>256</td><td>Memory usage of the search server app in MB. Supports units, for example, `1GB`, `512MB`.</td></tr>
 </table>
 
-
-### <a id='customize-apps-manager-invitations'></a> Configure Apps Manager Invitations
-
-To configure Apps Manager Invitations settings:
-
-1. Ensure the `apps-manager-values.yml` file has an `invitations:` section.  
-1. Ensure the `invitations:` section includes a `resources:` sub-section.  
-1. Add the desired property configuration, using `property: value` format. 
-See [Configurable Apps Manager Invitations Settings](#apps-manager-invitations-settings) below.
-1. Review the completed file. The configuration file you create 
-should be a well formatted YAML file.  
-<br>
-    For example:  
-
-    ```yaml
-    #@library/ref "@github.com/pivotal/apps-manager-k8s-release"
-    #@data/values
-    ---
-    invitations:
-      resources:
-        instances: 2
-        memory: 256
-    ```
-1. Save the configuration file.
-
-#### <a id='apps-manager-invitations-settings'></a> Configurable Apps Manager Invitations Settings
-The following are all of the configurable Apps Manager Invitations settings:
-<table class="nice">
-  <tr>
-    <th width="40%">Property</th>
-    <th widt="20%">Default Value</th>
-    <th width="40%">Description</th>
-  </tr>
-<tr><td>instances</td><td>2</td><td>Deployed instances of Apps Manager Invitations.</td></tr>
-<tr><td>memory</td><td>256</td><td>Memory usage of the invitations apps in MB. Supports units, for example, `1GB`, `512MB`.</td></tr>
-</table>
 
 ### <a id='customize-apps-manager-white-label'></a> Configure Apps Manager White-Labeling
 
@@ -333,7 +283,6 @@ The following are all of the configurable Apps Manager "whitelabeling", "resourc
   </tr>
 <tr><td>apps\_manager.currency\_lookup</td><td> '{"usd":"$","eur":"€"}'</td><td>Supported currency symbols</td></tr>
 <tr><td>apps\_manager.display\_plan\_prices</td><td>false</td><td>Display Marketplace Service Plan Prices</td></tr>
-<tr><td>apps\_manager.enable\_invitations</td><td>false</td><td>Enable inviting users through the invitation service</td></tr>
 <tr><td>apps\_manager.poll\_interval</td><td>30</td><td>The Apps Manager poll interval. Enter value in seconds.</td></tr>
 <tr><td>apps\_manager.app\_details\_poll\_interval</td><td>10</td><td>The app details polling interval. Enter value in seconds.</td></tr>
 <tr><td>apps\_manager.whitelabeling.app\_icon</td><td>tanzu icon</td><td>Icon for apps manager UAA portal link</td></tr>
@@ -352,10 +301,6 @@ The following are all of the configurable Apps Manager "whitelabeling", "resourc
 <tr><td>apps\_manager.whitelabeling.marketplace\_url</td><td>"/marketplace"</td><td>Apps Manager Marketplace link to point to a custom marketplace.</td></tr>
 <tr><td>apps\_manager.whitelabeling.secondary\_navigation\_links</td><td>'[{"name":"Docs","href":"https&#58;//docs.run.pivotal.io"},{"name":"Tools","href"&#58;"/tools"}]'</td><td>List of secondary navigation links of Apps Manager. Enter json string.</td></tr>
 <tr><td>apps\_manager.resources.instances</td><td>1</td><td>Deployed Instances of Apps Manager</td></tr>
-<tr><td>apps\_manager.resources.memory</td><td>128</td><td>Memory usage of Apps Manager in MB. Supports units, for example, `1GB`, `512MB`.</td></tr>
 <tr><td>search\_server.resources.instances</td><td>2</td><td>Deployed Instances of Apps Manager</td></tr>
-<tr><td>search\_server.resources.memory</td><td>256</td><td>Memory usage of the search server app in MB. Supports units, for example, `1GB`, `512MB`.</td></tr>
-<tr><td>invitations.resources.instances</td><td>2</td><td>Deployed Instances of Apps Manager</td></tr>
-<tr><td>invitations.resources.memory</td><td>256</td><td>Memory usage of the invitations apps in MB. Supports units, for example, `1GB`, `512MB`.</td></tr>
 </table>
 %>

--- a/configuring-apps-manager.html.md.erb
+++ b/configuring-apps-manager.html.md.erb
@@ -30,7 +30,7 @@ For more information about Apps Manager, see
 [Getting Started with Apps Manager](https://docs.run.pivotal.io/console/dev-console.html).
 
 <p class="note"><strong>Note:</strong> Users are currently unable to invite members to orgs and spaces through Apps Manager.
-  This feature depends on the Notifications Service, which is not yet available on TAS for Kubernetes.
+  This feature depends on the Notifications Service, which is not available on TAS for Kubernetes.
 </p>
 
 


### PR DESCRIPTION
Hi Docs Team,

This PR removes the Invitation configuration instructions since that feature will no longer be part of GA.
This also removes some unused properties.
The changes should be listed on master and on 0-4.

Thanks,
@weymanf @belinda-liu 