### PR TITLE
TPG has fixed a bug - updating docs

### DIFF
--- a/bandr-restore-manual.html.md.erb
+++ b/bandr-restore-manual.html.md.erb
@@ -108,8 +108,8 @@ in _Configuring Your System Databases_.
     kubectl -n postgres-dbs exec -it pod/ccdb-0 -- pgbackrest --stanza=ccdb --delta restore
     kubectl -n postgres-dbs exec -it pod/uaadb-0 -- pg_ctl stop
     kubectl -n postgres-dbs exec -it pod/uaadb-0 -- pgbackrest --stanza=uaadb --delta restore
-    kubectl -n postgres-dbs delete pod/ccdb-0
-    kubectl -n postgres-dbs delete pod/uaadb-0
+    kubectl -n postgres-dbs exec -it pod/ccdb-0 -- pg_ctl start
+    kubectl -n postgres-dbs exec -it pod/uaadb-0 -- pg_ctl start
     ```
 
 1. To re-annotate and label your pods, complete


### PR DESCRIPTION
The Tanzu Postgres team have fixed a bug which led to these lines being needed. The command no longer needs to delete pods, but instead just re-start the process on the container.