### PR TITLE
Update configuring-system-databases.html.md.erb

### DIFF
--- a/configuring-system-databases.html.md.erb
+++ b/configuring-system-databases.html.md.erb
@@ -49,7 +49,7 @@ To configure these three databases:
       cpu: "0.5"
       storageClassName: STORAGE-CLASS
       serviceType: ClusterIP
-      storageSize: 300M
+      storageSize: 10G
       pgConfig:
         dbname: cloud_controller
         username: cloud_controller
@@ -64,7 +64,7 @@ To configure these three databases:
       cpu: "0.5"
       storageClassName: STORAGE-CLASS
       serviceType: ClusterIP
-      storageSize: 300M
+      storageSize: 10G
       pgConfig:
         dbname: uaa
         username: uaa
@@ -79,7 +79,7 @@ To configure these three databases:
       cpu: "0.5"
       storageClassName: STORAGE-CLASS
       serviceType: ClusterIP
-      storageSize: 300M
+      storageSize: 10G
       pgConfig:
         dbname: usage_service
         username: usage_service


### PR DESCRIPTION
Update the recommended storage size for system databases from 300M to 10G so that customers don't routinely run out of disk when they use our sample configuration.