### PR TITLE
Update B/R docs to use vanilla velero

### DIFF
--- a/bandr-backup-manual.html.md.erb
+++ b/bandr-backup-manual.html.md.erb
@@ -19,22 +19,20 @@ To back up <%= vars.app_runtime_short %>:
 * [Monitor Backup Progress](#backup-progress)
 * [Review a Completed Backup](#backup-review)
 
-## <a id='prerequisites'></a> Prerequisites
-
 ## <a id='backup-tas4k8s'></a> Back Up <%= vars.app_runtime_short %>
 
 To back up <%= vars.app_runtime_short %> Tanzu Postgres Instances:
 
-1. To back up the PGBackrest volume and secrets:
+1. Start a velero backup:
 
     ```
     velero create backup BACKUP-NAME \
-	--include-namespaces NAMESPACES \
-	--selector ‘app in (RESOURCE-LIST)` \
-	--storage-location STORAGE-LOCATION \
-	--ttl TTL-LENGTH \
-	--wait
-	```
+    	--include-namespaces NAMESPACES \
+    	--selector ‘app in (RESOURCE-LIST)` \
+    	--storage-location STORAGE-LOCATION \
+    	--ttl TTL-LENGTH \
+    	--wait
+  	```
 
     Where:
     * `BACKUP-NAME` is the name to apply to the generated backup.
@@ -60,19 +58,16 @@ To back up <%= vars.app_runtime_short %> Tanzu Postgres Instances:
 <br>
     * (Optional) Include the `--wait` parameter to follow the backup procedure progress.
 <br>
-  The recommended command line is:
 
-    ```
-    velero create backup BACKUP-NAME \
+The recommended command line is:
+
+```
+velero create backup BACKUP-NAME \
 	--include-namespaces postgres-dbs,cf-system \
 	--selector ‘app in (postgres, cf-metadata)` \
-	--storage-location STORAGE-LOCATION \
-	--ttl TTL-LENGTH \
+	--ttl 35040h0m0s \
 	--wait
-	```
-
-
-
+```
 
 ## <a id='backup-progress'></a> Monitor Backup Progress
 
@@ -156,7 +151,7 @@ To validate a completed backup by reviewing the Cloud Foundry data that was back
 
     Where `BACKUP-NAME` is the name you applied to your backup.
 <br>
-    (Optional) Include the `--details` parameter to display a highly verbose output.  
+    (Optional) Include the `--details` parameter to display a highly verbose output.
 <br>
     For example:
 

--- a/bandr-configuration.html.md.erb
+++ b/bandr-configuration.html.md.erb
@@ -1,9 +1,9 @@
----
+--
 title: Configuring Back Up and Restore for Tanzu Application Service for Kubernetes
 owner: Tanzu Application Service Release Engineering
 ---
 
-This topic provides an overview of how to configure back up and recovery for 
+This topic provides an overview of how to configure back up and recovery for
 <%= vars.app_runtime_full %> (<%= vars.app_runtime_short %>).
 
 <%= partial 'evaluation_only' %>
@@ -12,28 +12,22 @@ This topic provides an overview of how to configure back up and recovery for
 
 ## <a id='overview'></a> Overview
 
-After installing <%= vars.app_runtime_short %>, you must 
-prepare your <%= vars.app_runtime_short %> Postgres databases for backup and restore operations.
-To prepare your <%= vars.app_runtime_short %> Postgres databases, see 
-[Prepare Postgres Databases for Backup](#prepare-postgres) below.  
-
-To enable backup and recovery functions for <%= vars.app_runtime_short %>, 
-install and configure Velero in your environment. 
+To enable backup and recovery functions for <%= vars.app_runtime_short %>,
+install and configure Velero in your environment.
 To install and configure Velero, see [Set Up and Install Velero and Back Up Components]
 (#setup-backup-comp) below.
 
-
 ## <a id='prerequisites'></a> Prerequisites
 
-The following are required before configuring backup and recovery for <%= vars.app_runtime_short %>:  
+The following are required before configuring backup and recovery for <%= vars.app_runtime_short %>:
 
-* <%= vars.app_runtime_short %> has been installed. For more information, see 
-[Installing Tanzu Application Service for Kubernetes](installing-tas-for-kubernetes.html).  
-* <%= vars.app_runtime_short %> has been configured 
-to use an external Tanzu Postgres Pod for the CCDB and UAA databases.  
-* Kubernetes command line tool (kubectl) has been installed in your environment. 
-For more information, see [Installing Command-Line Tools](installing-command-line-tools.html).  
-* A working Kubernetes cluster. 
+* <%= vars.app_runtime_short %> has been installed. For more information, see
+[Installing Tanzu Application Service for Kubernetes](installing-tas-for-kubernetes.html).
+* <%= vars.app_runtime_short %> has been configured
+to use an external Tanzu Postgres Pod for the CCDB and UAA databases.
+* Kubernetes command line tool (kubectl) has been installed in your environment.
+For more information, see [Installing Command-Line Tools](installing-command-line-tools.html).
+* A working Kubernetes cluster.
 For more information, see [Supported Kubernetes Distributions]
 (release-notes.html#supported-platforms) in _Release Notes_.
 
@@ -41,167 +35,121 @@ For more information, see [Supported Kubernetes Distributions]
 
 The following are additional requirements for configuring backup and recovery for <%= vars.app_runtime_short %> on vSphere:
 
-* The vSphere backup and recovery user account must meet additional requirements:  
-    * vSphere CSI driver user requirements. 
+* The vSphere backup and recovery user account must meet additional requirements:
+    * vSphere CSI driver user requirements.
     For more information on the vSphere CSI Driver requirements, see [vSphere Roles and Privileges]
-    (https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/prerequisites.html#roles_and_privileges) 
-    in the _vSphere CSI Driver - Prerequisites_ documentation.  
-    * Virtual Disk Development Kit (VDDK) user requirements. 
+    (https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/prerequisites.html#roles_and_privileges)
+    in the _vSphere CSI Driver - Prerequisites_ documentation.
+    * Virtual Disk Development Kit (VDDK) user requirements.
     For more information on the VDDK requirements, see [Credentials and Privileges for VMDK Access]
-    (https://code.vmware.com/docs/11750/virtual-disk-development-kit-programming-guide/GUID-8301C6CF-37C2-42CC-B4C5-BB1DD28F79C9.html) 
+    (https://code.vmware.com/docs/11750/virtual-disk-development-kit-programming-guide/GUID-8301C6CF-37C2-42CC-B4C5-BB1DD28F79C9.html)
     in the _Virtual Disk Development Kit Programming Guide_ documentation.
- <br>   
-    Apply user privileges at the vCenter Server level.  
-* The installed components must meet the following supported product requirements:  
-    * Velero: v1.3.2 or later  
-    * vSphere: v6.7U3 or later  
-    * vSphere CSI/CNS driver: v1.0.2 or later  
+ <br>
+    Apply user privileges at the vCenter Server level.
+* The installed components must meet the following supported product requirements:
+    * Velero: v1.3.2 or later
+    * vSphere: v6.7U3 or later
+    * vSphere CSI/CNS driver: v1.0.2 or later
     * Kubernetes: v1.14 or later
 
-    For more information, see [Compatibility](https://github.com/vmware-tanzu/velero-plugin-for-vsphere#compatibility) 
-and [Prerequisites](https://github.com/vmware-tanzu/velero-plugin-for-vsphere#prerequisites) 
+    For more information, see [Compatibility](https://github.com/vmware-tanzu/velero-plugin-for-vsphere#compatibility)
+and [Prerequisites](https://github.com/vmware-tanzu/velero-plugin-for-vsphere#prerequisites)
 in _Velero Plugin for vSphere_ in GitHub.
-
-
-
-## <a id='prepare-postgres'></a> Prepare Postgres Databases for Backup
-
-To prepare your <%= vars.app_runtime_short %> Postgres instances for backup and restore:  
-
-1. Complete the steps in [Setting up the Environment]
-(http://postgres-kubernetes.docs.pivotal.io/1-0/backup-restore.html#backup_prerequisites) 
-in the _VMware Tanzu SQL for Postgres_ documentation.  
-
-1. Annotate the Postgres Pods to ensure full backups are made through Velero:
-
-    ```
-    kubectl -n postgres-dbs annotate pod \
-      ccdb-0 \
-      '["/bin/bash", "-c", "pgbackrest stanza-create --stanza=ccdb --pg1-path=/pgsql/data && pgbackrest backup --stanza=ccdb"]' \
-      'pre.hook.backup.velero.io/timeout=120s'
-
-    kubectl -n postgres-dbs annotate pod \
-      uaadb-0 \
-      '["/bin/bash", "-c", "pgbackrest stanza-create --stanza=uaadb --pg1-path=/pgsql/data && pgbackrest backup --stanza=uaadb"]' \
-      'pre.hook.backup.velero.io/timeout=120s'
-    ```
-
-
-1. To verify the annotations have been applied:  
-
-    ```
-    kubectl -n postgres-dbs get pod -o jsonpath='{.items[*].metadata.annotations}'
-    ```
-
-    For example:
-    <pre class="terminal">
-    kubectl -n postgres-dbs get pod -o jsonpath='{.items[*].metadata.annotations}'
-    {
-      "pre.hook.backup.velero.io/command": "[\"pgbackrest\",\"--stanza=ccdb\",\"--type=full\",\"backup\"]",
-      "pre.hook.backup.velero.io/timeout": "60s"
-    }
-    {
-      "pre.hook.backup.velero.io/command": "[\"pgbackrest\",\"--stanza=uaadb\",\"--type=full\",\"backup\"]",
-      "pre.hook.backup.velero.io/timeout": "60s"
-    }
-    </pre>
-
 
 ## <a id='setup-backup-comp'></a> Set Up and Install Velero and Back Up Components
 
-Velero and an Iaas specific Velero plugin must be installed to back up and restore <%= vars.app_runtime_short %>.  
+Velero and an Iaas specific Velero plugin must be installed to back up and restore <%= vars.app_runtime_short %>.
 
-The Velero plugin requires specific IaaS permissions to enable 
+The Velero plugin requires specific IaaS permissions to enable
 disk snapshotting, storage bucket read/write permissions and other backup and restore features.
 
-To set up back up components:  
+To set up back up components:
 
 1. To install the Velero CLI, see [Install the CLI]
-(https://velero.io/docs/v1.4/basic-install/#install-the-cli) 
-in the Velero documentation.  
+(https://velero.io/docs/v1.4/basic-install/#install-the-cli)
+in the Velero documentation.
 
-1. To install the Velero plug-in and configure back up components, 
-follow the steps required by your IaaS:  
-    * [Set Up Back Up Components on AWS](#setup-backup-comp-aws)  
+1. To install the Velero plug-in and configure back up components,
+follow the steps required by your IaaS:
+    * [Set Up Back Up Components on AWS](#setup-backup-comp-aws)
     * [Set Up Back Up Components on Azure](#setup-backup-comp-azure)
     * [Set Up Back Up Components on GCP](#setup-backup-comp-gcp)
-    * [Set Up Back Up Components on vSphere](#setup-backup-comp-vsphere)  
+    * [Set Up Back Up Components on vSphere](#setup-backup-comp-vsphere)
 
 
 ### <a id='setup-backup-comp-aws'></a> Set Up Back Up Components on AWS
 
-To install and configure Velero for <%= vars.app_runtime_short %> on AWS:  
+To install and configure Velero for <%= vars.app_runtime_short %> on AWS:
 
 1. To create a storage bucket for Velero, follow the steps in [Create S3 bucket]
-(https://github.com/vmware-tanzu/velero-plugin-for-aws#Create-S3-bucket) 
+(https://github.com/vmware-tanzu/velero-plugin-for-aws#Create-S3-bucket)
 in _Velero plugins for AWS_ in GitHub.
 
 1. To grant access permissions, follow the steps in [Set permissions for Velero]
-(https://github.com/vmware-tanzu/velero-plugin-for-aws#Set-permissions-for-Velero) 
+(https://github.com/vmware-tanzu/velero-plugin-for-aws#Set-permissions-for-Velero)
 in _Velero plugins for AWS_ in GitHub.
 
 1. To install Velero, follow the steps in [Install and start Velero]
-(https://github.com/vmware-tanzu/velero-plugin-for-aws#Install-and-start-Velero) 
-in _Velero plugins for AWS_ in GitHub.  
+(https://github.com/vmware-tanzu/velero-plugin-for-aws#Install-and-start-Velero)
+in _Velero plugins for AWS_ in GitHub.
 
 
 ### <a id='setup-backup-comp-azure'></a> Set Up Back Up Components on Azure
 
-To install and configure Velero for <%= vars.app_runtime_short %> on Azure:  
+To install and configure Velero for <%= vars.app_runtime_short %> on Azure:
 
 1. To create a storage container for Velero, follow the steps in [Create Azure storage account and blob container]
-(https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#Create-Azure-storage-account-and-blob-container) 
+(https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#Create-Azure-storage-account-and-blob-container)
 in _Velero plugins for Azure_ in GitHub.
 
 1. To grant access permissions, follow the steps in [Set permissions for Velero]
-(https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#Set-permissions-for-Velero) 
+(https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#Set-permissions-for-Velero)
 in _Velero plugins for Microsoft Azure_ in GitHub.
 
 1. To install Velero, follow the steps in [Install and start Velero]
-(https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#Install-and-start-Velero) 
-in _Velero plugins for Azure_ in GitHub.  
+(https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#Install-and-start-Velero)
+in _Velero plugins for Azure_ in GitHub.
 
 
 ### <a id='setup-backup-comp-gcp'></a> Set Up Back Up Components on GCP
 
-To install and configure Velero for <%= vars.app_runtime_short %> on GCP:  
+To install and configure Velero for <%= vars.app_runtime_short %> on GCP:
 
 1. To create a storage container for Velero, follow the steps in [Create an GCS bucket]
-(https://github.com/vmware-tanzu/velero-plugin-for-gcp#Create-an-GCS-bucket) 
+(https://github.com/vmware-tanzu/velero-plugin-for-gcp#Create-an-GCS-bucket)
 in _Plugins for Google Cloud Platform (GCP)_ in GitHub.
 
 1. To grant access permissions, follow the steps in [Set permissions for Velero]
-(https://github.com/vmware-tanzu/velero-plugin-for-gcp#Set-permissions-for-Velero) 
+(https://github.com/vmware-tanzu/velero-plugin-for-gcp#Set-permissions-for-Velero)
 in _Plugins for Google Cloud Platform (GCP)_ in GitHub.
 
 1. To install Velero, follow the steps in [Install and start Velero]
-(https://github.com/vmware-tanzu/velero-plugin-for-gcp#Install-and-start-Velero) 
-in _Plugins for Google Cloud Platform (GCP)_ in GitHub.  
+(https://github.com/vmware-tanzu/velero-plugin-for-gcp#Install-and-start-Velero)
+in _Plugins for Google Cloud Platform (GCP)_ in GitHub.
 
 
 ### <a id='setup-backup-comp-vsphere'></a> Set Up Back Up Components on vSphere
 
-To install and configure Velero for <%= vars.app_runtime_short %> on vSphere:  
+To install and configure Velero for <%= vars.app_runtime_short %> on vSphere:
 
-1. Confirm you have completed the steps in [Prerequisites for vSphere](#prerequisites-vsphere) above.  
-1. To create a storage location for Velero:  
+1. Confirm you have completed the steps in [Prerequisites for vSphere](#prerequisites-vsphere) above.
+1. To create a storage location for Velero:
 
-    1. Follow the steps in 
+    1. Follow the steps in
 [Create a VolumeSnapshotLocation](https://github.com/vmware-tanzu/velero-plugin-for-vsphere#Create-a-VolumeSnapshotLocation)
-in _Velero Plugin for vSphere_ in GitHub.  
+in _Velero Plugin for vSphere_ in GitHub.
 
-    1. Follow the steps in 
+    1. Follow the steps in
 [Setting a default VolumeSnapshotLocation](https://github.com/vmware-tanzu/velero-plugin-for-vsphere#setting-a-default-volumesnapshotlocation)
-in _Velero Plugin for vSphere_ in GitHub.  
+in _Velero Plugin for vSphere_ in GitHub.
 
 1. To grant access permissions, follow the steps in [Set permissions for Velero]
-(https://github.com/vmware-tanzu/velero-plugin-for-aws#Set-permissions-for-Velero) 
+(https://github.com/vmware-tanzu/velero-plugin-for-aws#Set-permissions-for-Velero)
 in _Velero plugins for AWS_ in GitHub.
 
 1. To install Velero, follow the steps in [Install and start Velero]
-(https://github.com/vmware-tanzu/velero-plugin-for-aws#Install-and-start-Velero) 
-in _Velero plugins for AWS_ in GitHub.  
+(https://github.com/vmware-tanzu/velero-plugin-for-aws#Install-and-start-Velero)
+in _Velero plugins for AWS_ in GitHub.
 
 <p class="note"><strong>Note:</strong> The Velero Plug-in for vSphere does not support Guest or Supervisor clusters on vSphere.
 </p>
-

--- a/bandr-restore-manual.html.md.erb
+++ b/bandr-restore-manual.html.md.erb
@@ -16,8 +16,9 @@ This topic provides an overview of how to restore
 Velero supports a granular restore, which means you can tell velero to restore only specific resources from the backup. Unfortunately this is not the case for <%= vars.app_runtime_short %> database backup, it has no granularity and all the organizations, spaces & application will be restored as one.
 
 You do have 2 options while restoring <%= vars.app_runtime_short %>:
-Restore to a new platform with no state - this scenario is typical for a full disaster recovery
-Restore in place while deleting all current state of the platform - this scenario maybe used when things went so bad that it is worth losing some recent changes in favor of restoring a healthy baseline
+
+1. Restore to a new platform with no state - this scenario is typical for a full disaster recovery
+1. Restore in place while deleting all current state of the platform - this scenario maybe used when things went so bad that it is worth losing some recent changes in favor of restoring a healthy baseline
 
 * [Restore <%= vars.app_runtime_short %>](#restore-tas)
 * [Monitor Restore Progress](#restore-monitoring)
@@ -33,7 +34,7 @@ You must have access to the <%= vars.app_runtime_short %> Velero backup artifact
 To restore a <%= vars.app_runtime_short %> backup:
 
 * [Prepare the Velero Backup Artifacts](#restore-prepare)
-* [Start a <%= vars.app_runtime_short %> Restore](#restore-start)
+* [Start a <%= vars.app_runtime_short %> Velero Restore](#restore-start)
 
 ### <a id='restore-prepare'></a> Prepare the Velero Backup Artifacts
 
@@ -49,7 +50,7 @@ To prepare your <%= vars.app_runtime_short %> Velero backup artifacts:
 generate a JSON file containing a snapshot of Cloud Foundry at the time of the backup.
 
     ```
-    ./bin/get-backup-metadata.sh BACKUP-NAME OUTPUT-FILENAME
+    ./tanzu-application-service/config/_ytt_lib/github.com/pivotal/cf-for-k8s-disaster-recovery/backup-metadata/bin/get-backup-metadata.sh BACKUP-NAME OUTPUT-FILENAME
     ```
 
     Where:
@@ -58,104 +59,135 @@ generate a JSON file containing a snapshot of Cloud Foundry at the time of the b
 
     For example:
     <pre class="terminal">
-    $ ./bin/get-backup-metadata.sh backup_1 output-file.json
+    $ ./tanzu-application-service/config/_ytt_lib/github.com/pivotal/cf-for-k8s-disaster-recovery/backup-metadata/bin/get-backup-metadata.sh backup_1 output-file.json
     </pre>
 
-### <a id='restore-start'></a> Start a <%= vars.app_runtime_short %> Restore of Tanzu Postgres
-
-To restore <%= vars.app_runtime_short %> Tanzu Postgres Instances: 
-
-1. To fetch the name of the backup to restore:
+1. To prepare database resources for a restoration:
 
     ```
-    kubectl -n postgres-dbs exec -t pgbackrest info --stanza=ccdb  
+    kubectl -n postgres-dbs delete postgres.sql.tanzu.vmware.com/ccdb --wait
+    kubectl -n postgres-dbs delete pvc --selector postgres-instance=ccdb
+    kubectl -n postgres-dbs delete postgres.sql.tanzu.vmware.com/uaadb --wait
+    kubectl -n postgres-dbs delete pvc --selector postgres-instance=uaadb
     ```
 
-1. [Restore the CCDB Tanzu Postgres Database](#restore-ccdb)
-1. [Restore the UAADB Tanzu Postgres Database](#restore-uaadb)
+    The `--wait` parameter is optional. Include the `--wait` parameter to follow the restore procedure progress.
+
+    <p class="note"><strong>Note:</strong> This process deletes some kubernetes resources
+    to force velero to restore the db pod's persistent volume to the snapshotted version.
+    This is required to restore the correct data.
+    </p>
 
 
-#### <a id='restore-ccdb'></a> Restore the CCDB Tanzu Postgres Database 
+### <a id='restore-start'></a> Start a <%= vars.app_runtime_short %> Velero Restore
 
-To restore <%= vars.app_runtime_short %> CCDB Tanzu Postgres Instance:
+To restore <%= vars.app_runtime_short %> Tanzu Postgres Instances:
 
-1. To fetch the pid for the CCDB `pg_auto_failover` child process:  
-
-    ```
-    kubectl -n postgres-dbs exec -t ccdb-0 -- ps -ef | grep "pg_autoctl: start/stop postgres" | grep -v grep | awk '{print $2}'
-    ```
-
-1. To stop the the CCDB `pg_auto_failover` child process:  
+1. To restore Tanzu Postgres Databases:
 
     ```
-    kubectl -n postgres-dbs exec -t ccdb-0 -- kill -STOP CCDB-PID
+    velero create restore RESTORE-NAME \
+      --from-backup BACKUP-NAME \
+      --wait
     ```
 
-    Where `CCDB-PID` is the pid you collected in the last step.
+    Where:
+    * `BACKUP-NAME` is the name of the velero backup artifact to be restored.
+    * `RESTORE-NAME` is a name you choose to identify this restore attempt.
 
-1. To stop the Postgres instance:  
+    The `--wait` parameter is optional. Include the `--wait` parameter to follow the restore procedure progress.
 
-    ```
-    kubectl -n postgres-dbs exec -t ccdb-0 -- pg_ctl stop
-    ```
+## <a id='restore-monitoring'></a> Monitor Restore Progress
 
-1. To restore the CCDB Postgres database:  
+To inspect the status of a restore:
 
-    ```
-    kubectl -n postgres-dbs exec -t ccdb-0 -- pgbackrest restore --stanza=ccdb --delta --db-include=cloud_controller --type name --target BACKUP-NAME
-    ```
+* [Review All Restores](#restore-monitor-all)
+* [Inspect a Single Restore](#restore-monitor-single)
 
-     Where `BACKUP-NAME` is the name of the backup you want to restore from.  
+### <a id='restore-monitor-all'></a> Review All Restores
 
-1. To restart the CCDB `pg_auto_failover` child process and restart the Postgres process:  
+To see the names and status of all restores:
 
-    ```
-    kubectl -n postgres-dbs exec -t ccdb-0 -- kill -CONT CCDB-PID
-    ```
-
-    Where `CCDB-PID` is the pid you collected in the step above.
-
-#### <a id='restore-uaadb'></a> Restore the UAADB Tanzu Postgres Database 
-
-To restore <%= vars.app_runtime_short %> UAADB Tanzu Postgres Instance:
-
-1. To fetch the pid for the UAADB `pg_auto_failover` child process:  
+1. Open a command line.
+1. To display information about all restores:
 
     ```
-    kubectl -n postgres-dbs exec -t uaadb-0 -- ps -ef | grep "pg_autoctl: start/stop postgres" | grep -v grep | awk '{print $2}'
+    velero get restores
     ```
 
-1. To stop the the UAADB `pg_auto_failover` child process:      
+    For example:
+
+    <pre class="terminal">
+    $ velero get restores
+
+    NAME    STATUS                       CREATED EXPIRES STORAGE LOCATION  SELECTOR
+    restore_1 Completed 2020-03-24 14:12:29 +0000 UTC    21d          default    &lt;none&gt;
+    </pre>
+
+### <a id='restore-monitor-single'></a> Inspect a Single Restore
+
+To review the status of a single restore:
+
+1. Determine the name of the restore. For more information, see [Review All Restores](#restore-monitor-all) above.
+1. To display information about a single restore:
 
     ```
-    kubectl -n postgres-dbs exec -t uaadb-0 -- kill -STOP UAADB-PID
+    velero describe restore RESTORE-NAME
     ```
 
-    Where `UAADB-PID` is the pid you collected in the last step.
+    For example:
 
-1. To stop the Postgres instance:  
+    <pre class="terminal">
+    $ velero describe restore MY_RESTORE_NAME
+    Note: Add --details flag for highly verbose output
+
+    Name:         MY_RESTORE_NAME
+    Namespace:    default
+    Labels:       &lt;none&gt;
+    Annotations:  &lt;none&gt;
+
+    Phase:  Completed
+
+    Backup:  MY_BACKUP_NAME
+
+    Namespaces:
+      Included:  *
+      Excluded:  &lt;none&gt;
+
+    Resources:
+      Included:        *
+      Excluded:        nodes, events, events.events.k8s.io, backups.velero.io, restores.velero.io, resticrepositories.velero.io
+      Cluster-scoped:  auto
+
+    Namespace mappings:  &lt;none&gt;
+
+    Label selector:  &lt;none&gt;
+
+    Restore PVs:  auto
+    </pre>
+
+## <a id='restore-review'></a> Review a Completed Restore
+
+To review and validate a completed restore:
+
+* [Review Restore Logs](#restore-monitor-logs)
+* [Validate the Restore](#restore-validate)
+* [Troubleshoot a Failed Restore](#restore-troubleshoot)
+
+### <a id='restore-monitor-logs'></a> Review Restore Logs
+
+You can inspect the logs for your restore after the restore has completed.
+Review the logs for any failures and their root causes.
+
+1. To review the logs for a particular restore:
 
     ```
-    kubectl -n postgres-dbs exec -t uaadb-0 -- pg_ctl stop
+    velero restore logs RESTORE-NAME
     ```
 
-1. To restore the UAADB Postgres database:  
+    Where `RESTORE-NAME` is name you provided as your restore name.
 
-    ```
-    kubectl -n postgres-dbs exec -t uaadb-0 -- pgbackrest restore --stanza=uaadb --delta --db-include=uaa --type name --target BACKUP-NAME
-    ```
 
-     Where `BACKUP-NAME` is the name of the backup you want to restore from.  
-
-1. To restart the UAADB `pg_auto_failover` child process and restart the Postgres process:  
-
-    ```
-    kubectl -n postgres-dbs exec -t uaadb-0 -- kill -CONT UAADB-PID
-    ```
-
-    Where `UAADB-PID` is the pid you collected in the step above.
-
-	
 ### <a id='restore-validate'></a> Validate the Restore
 
 Given a restore has completed and there were no errors or warnings,
@@ -206,7 +238,7 @@ Confirm the following are present in the `tanzu-application-service/config/_ytt_
 
     For example:
     <pre class="terminal">
-    $ ./bin/get-backup-metadata.sh backup_1 output-file.json
+    $ ./tanzu-application-service/config/_ytt_lib/github.com/pivotal/cf-for-k8s-disaster-recovery/backup-metadata/bin/get-backup-metadata.sh backup_1 output-file.json
     </pre>
 
 1. To compare the backup state to the restored system state:


### PR DESCRIPTION
+ Tanzu Postgres has recommended snapshotting as a strategy for B/R
  instead of invoking `pgbackrest`. This simlifies our docs

+ Sorry, my text editor fixed alot of the whitespace. Hope that's ok 👍 
+ There will be one final PR soon which will change the path of `./tanzu-application-service/config/_ytt_lib/github.com/pivotal/cf-for-k8s-disaster-recovery/backup-metadata/bin/get-backup-metadata.sh` to reflect it's move to `cf4k8s` project.