### PR TITLE
Fix link to TKG docs

### DIFF
--- a/preparing-kubernetes-cluster.html.md.erb
+++ b/preparing-kubernetes-cluster.html.md.erb
@@ -68,7 +68,7 @@ for <%= vars.app_runtime_short %> on TKG:
     the certificate of that CA.
 
 For information about setting up TKG, see [Installing Tanzu Kubernetes Grid]
-(https://docs.com/en/VMware-Tanzu-Kubernetes-Grid/1.0/vmware-tanzu-kubernetes-grid-10/GUID-install-tkg-index.html).
+(https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.0/vmware-tanzu-kubernetes-grid-10/GUID-install-tkg-index.html).
 
 After creating the cluster, run `tkg get credentials CLUSTER-NAME` to get the context name and `kubectl config use-context CONTEXT-NAME` to ensure that kubectl targets the cluster.
 


### PR DESCRIPTION
The link is incorrect and needs to be fixed starting in 0.6 docs

This should also me made in any future versions of the docs.

@ram-pivot 