### PR TITLE
document known issue with the compare-backup-metadata script

### DIFF
--- a/bandr-restore-manual.html.md.erb
+++ b/bandr-restore-manual.html.md.erb
@@ -256,6 +256,17 @@ To validate a completed restore:
 
 1. To compare the backup state to the restored system state:
 
+    <p class="note warning"><strong>Warning:</strong> There is a known issue with the compare-backup-metadata.sh script below due to the `cf-metadata` container
+    no longer being the default container in the Pod. To use it you will need to modify the script to specify the container with the `-c cf-metadata` flag.</p>
+
+    The final line of the `compare-backup-metadata.sh` script should look like:
+
+    ```
+    kubectl ${NAMESPACE} exec -it "${POD_NAME}" -c cf-metadata -- bash -ce 'backup-metadata compare' < "$1"
+    ```
+
+    Run the script:
+
     ```
     tanzu-application-service/config/_ytt_lib/github.com/pivotal/cf-for-k8s-disaster-recovery/backup-metadata/bin/compare-backup-metadata.sh OUTPUT-FILENAME
     ```


### PR DESCRIPTION
The version of this script that ships with 0.6 and 0.7 has an issue due to the `cf-metadata` container no longer being the default container on its Pod. Users of these versions will need to modify the script for it to run successfully so we wanted to make that clear in the docs. We had a bit of trouble figuring out how best to articulate / style this, so open to any feedback or corrections you want to make!

This may conflict slightly (but not too bad!) with the changes in @angelachin's PR https://github.com/pivotal-cf/docs-tas-kubernetes/pull/83.

**This commit should also be added to `0.6` and `master` branches.**

TAS4K8S Story: [#176366649](https://www.pivotaltracker.com/story/show/176366649)

cc @reneighbor 