### PR TITLE
Update configuring-installation-values.html.md.erb

### DIFF
--- a/configuring-installation-values.html.md.erb
+++ b/configuring-installation-values.html.md.erb
@@ -176,8 +176,8 @@ To configure optional application log destinations:
     * `HOSTNAME` is the hostname of the log destination.
     * `PORT` is the TCP port number of the log destination.
     * `TRANSPORT` is one of the following:
-      - `tls` for TLS-encrypted syslog over TCP.
-      - `tcp` for plaintext syslog over TCP. This is the default value.
+      - `tls` for TLS-encrypted syslog over TCP. This is the default value.
+      - `tcp` for plaintext syslog over TCP.
     * `DISABLE-TLS-VALIDATION` is `true` or `false`. If set to `true`, the
       destination TLS certificate is not validated. The default value is `false`.
 


### PR DESCRIPTION
Fix the app log destination doc to accurately represent the default values. The [`0.7`](https://github.com/pivotal-cf/docs-tas-kubernetes/blob/0.7/configuring-installation-values.html.md.erb#L179) and [`0.6`](https://github.com/pivotal-cf/docs-tas-kubernetes/blob/0.6/configuring-installation-values.html.md.erb#L179) branches already have the correct copy.

For additional context see: as https://github.com/pivotal-cf/docs-tas-kubernetes/pull/82

Thanks!