### PR TITLE
Document known issue with `kapp` and `antrea` <= v0.10.1

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -147,6 +147,10 @@ This release has the following issues:
 
  - **Apps Manager** does not support inviting members.
  - **Apps Manager** does not support creating container networking policies for apps.
+ - The `kapp` utility may fail to delete CF due to the version of Antrea used in TKGm 1.2.0 and 1.2.1. This issue can be worked around by specifying a filter to exclude Antrea resources during deletion:
+   ```
+   kapp delete -a cf --filter '{"not":{"resource":{"kinds":["AntreaControllerInfo"]}}}'
+   ```
  - Staging applications fail during `cf push` if you exceed the maximum image label size when using containerd v1.4.0 and 1.4.1. 
  Containerd version 1.4.1 is used by TKGm 1.2.1. To reduce the chances of exceeding the maximum image's label size, 
  reduce the number of buildpacks used by the cf-default-builder.  


### PR DESCRIPTION
There is a known issue with `antrea` and `kapp` that causes
errors when running `kapp delete -a cf`:

For example...
```
3:35:32PM: ongoing: delete antreacontrollerinfo/antrea-controller (system.antrea.tanzu.vmware.com/v1beta1) cluster
kapp: Error: Timed out waiting after 15m0s
```

This issue is fixed in newer versions of `antrea`, but TKGm 1.2.x has a susceptible version. TKGm versions that are older than this don't use Antrea and TKGm 1.3 has a newer version that has the fix.

Related story: [#176755265](https://www.pivotaltracker.com/story/show/176755265)

**This known issue should be included on the `0.7` and `master` branches.**

Thanks!

cc @matt-royal @angelachin 